### PR TITLE
Enforce numeric formatting

### DIFF
--- a/gemBS/commands.py
+++ b/gemBS/commands.py
@@ -106,6 +106,8 @@ def gemBS_main():
         else:
             path = f + ":" + path
             os.environ["PATH"] = path
+
+        os.environ["LC_NUMERIC"] = "C"
             
         commands = {
             "prepare" : PrepareConfiguration,            


### PR DESCRIPTION
Hi,
here is another minifix. I'm running this on a computer with , as decimal separator. This disrupts wigToBigWig that expects . (dot). The best fix I came up with was to enforce dot as comma separator by setting LC_NUMERIC = C.

I'm not sure where best to do this in the code. The suggested change works for me, but perhaps there is a better place to handle this.